### PR TITLE
Support serialization with Ruby's Marshal

### DIFF
--- a/lib/segment_tree.rb
+++ b/lib/segment_tree.rb
@@ -31,7 +31,25 @@ class SegmentTree
         else cmp
       end
     end
+
+    def ==(other)
+      other.is_a?(self.class) &&
+        @range == other.range &&
+        @value == other.value
+    end
+
+    def eql?(other)
+      other.is_a?(self.class) &&
+        @range.eql?(other.range) &&
+        @value.eql?(other.value)
+    end
+
+    def hash
+      [@range, @value].hash
+    end
   end
+
+  attr_reader :segments
 
   # Build a segment tree from +data+.
   #
@@ -81,6 +99,18 @@ class SegmentTree
     else
       "SegmentTree(empty)"
     end
+  end
+
+  def ==(other)
+    other.is_a?(self.class) && @segments == other.segments
+  end
+
+  def eql?(other)
+    other.is_a?(self.class) && @segments.eql?(other.segments)
+  end
+
+  def hash
+    @segments.hash
   end
 
   private

--- a/lib/segment_tree.rb
+++ b/lib/segment_tree.rb
@@ -47,6 +47,18 @@ class SegmentTree
     def hash
       [@range, @value].hash
     end
+
+    def marshal_dump
+      {
+        range: @range,
+        value: @value,
+      }
+    end
+
+    def marshal_load(serialized_tree)
+      @range = serialized_tree[:range]
+      @value = serialized_tree[:value]
+    end
   end
 
   attr_reader :segments
@@ -111,6 +123,16 @@ class SegmentTree
 
   def hash
     @segments.hash
+  end
+
+  def marshal_dump
+    {
+      segments: @segments,
+    }
+  end
+
+  def marshal_load(serialized_tree)
+    @segments = serialized_tree[:segments]
   end
 
   private

--- a/spec/segment_tree_spec.rb
+++ b/spec/segment_tree_spec.rb
@@ -131,4 +131,65 @@ describe SegmentTree do
       it { is_expected.to query(8).and_return(:nothing) }
     end
   end
+
+  describe '#==' do
+    subject { SegmentTree.new(sample_overlapping) }
+
+    it { is_expected.to eq(SegmentTree.new(sample_overlapping)) }
+    it { is_expected.not_to eq(SegmentTree.new(sample_overlapping2)) }
+
+    it 'is equal when a range coerces' do
+      expect(SegmentTree.new((1..2) => "a")).to eq(SegmentTree.new(((1.0)..(2.0)) => "a"))
+    end
+
+    it 'is equal when a value coerces' do
+      expect(SegmentTree.new((1..2) => 1)).to eq(SegmentTree.new((1..2) => 1.0))
+    end
+
+    it "isn't equal when only a range is different" do
+      expect(SegmentTree.new((1..2) => "a")).not_to eq(SegmentTree.new((1..3) => "a"))
+    end
+
+    it "isn't equal when only a value is different" do
+      expect(SegmentTree.new((1..2) => "a")).not_to eq(SegmentTree.new((1..2) => "b"))
+    end
+  end
+
+  describe '#eql?' do
+    subject { SegmentTree.new(sample_overlapping) }
+
+    it { is_expected.to be_eql(SegmentTree.new(sample_overlapping)) }
+    it { is_expected.not_to be_eql(SegmentTree.new(sample_overlapping2)) }
+
+    it "isn't equal when a range coerces" do
+      expect(SegmentTree.new((1..2) => "a")).not_to be_eql(SegmentTree.new(((1.0)..(2.0)) => "a"))
+    end
+
+    it "isn't equal when a value coerces" do
+      expect(SegmentTree.new((1..2) => 1)).not_to be_eql(SegmentTree.new((1..2) => 1.0))
+    end
+
+    it "isn't equal when only a range is different" do
+      expect(SegmentTree.new((1..2) => "a")).not_to be_eql(SegmentTree.new((1..3) => "a"))
+    end
+
+    it "isn't equal when only a value is different" do
+      expect(SegmentTree.new((1..2) => "a")).not_to be_eql(SegmentTree.new((1..2) => "b"))
+    end
+  end
+
+  describe '#hash' do
+    subject { SegmentTree.new(sample_overlapping).hash }
+
+    it { is_expected.to eq(SegmentTree.new(sample_overlapping).hash) }
+    it { is_expected.not_to eq(SegmentTree.new(sample_overlapping2).hash) }
+
+    it "isn't equal when only a range is different" do
+      expect(SegmentTree.new((1..2) => "a").hash).not_to eq(SegmentTree.new((1..3) => "a").hash)
+    end
+
+    it "isn't equal when only a value is different" do
+      expect(SegmentTree.new((1..2) => "a").hash).not_to eq(SegmentTree.new((1..2) => "b").hash)
+    end
+  end
 end

--- a/spec/segment_tree_spec.rb
+++ b/spec/segment_tree_spec.rb
@@ -192,4 +192,21 @@ describe SegmentTree do
       expect(SegmentTree.new((1..2) => "a").hash).not_to eq(SegmentTree.new((1..2) => "b").hash)
     end
   end
+
+  describe 'marshaling' do
+    it 'dumps and loads successfully' do
+      aggregate_failures do
+        [
+          sample_spanned,
+          sample_sparsed,
+          sample_overlapping,
+          sample_overlapping2,
+        ].each do |sample|
+          tree = SegmentTree.new(sample)
+          dumped = Marshal.dump(tree)
+          expect(Marshal.load(dumped)).to eq(tree)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
The first commit adds proper equality and hashing implementations; that's a general best practice, but the equality checks are also useful for the tests for the second commit that adds Marshal support.